### PR TITLE
Fix sensor data mapping for firmware and active heat source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix entity naming issue where entities appeared as "pool_controller_none" by adding proper English translations
 - Entities now display with descriptive names like "Pool Water Temperature", "Heat Delay Active", etc.
+- Fix Pool Controller Firmware sensor showing "Unknown" by using correct 'version' key from pycompool API
+- Fix Pool Controller Active Heat Source sensor by computing value from heater_on/solar_on status
+- Update temperature sensor key mappings to match pycompool library format
 
 ### Added
 - English translation file (`translations/en.json`) for proper entity naming
+- Computed field logic in coordinator for deriving active heat source from system status
+- Enhanced status data processing to handle pycompool API differences
+- Comprehensive sensor debugging documentation in CLAUDE.md
+
+### Technical Details
+- Updated const.py sensor key mappings to match pycompool API field names
+- Added _enhance_status_data() method in coordinator to compute derived sensor values
+- Updated test mock data to reflect actual pycompool response structure
 
 ## [0.1.0] - Initial Release
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,13 @@ The integration utilizes pycompool APIs:
 - ✅ `get_status()` - Used for connection validation and data polling
 - ✅ Connection management - Automatic connect/disconnect for each status query
 
+### Important API Data Structure Notes
+- **Firmware Version**: pycompool returns `"version"` key (integer), not `"firmware"` 
+- **Active Heat Source**: No direct field - must be computed from `heater_on` and `solar_on` boolean status
+- **Temperature Keys**: Follow specific naming conventions (e.g., `air_temp_f`, `pool_solar_temp_f`, `spa_solar_temp` without _f suffix)
+- **Time Format**: Returns as "HH:MM" string format, not ISO timestamp
+- **Status Fields**: Include `heater_on`, `solar_on`, `freeze_protection_active`, sensor fault flags
+
 ### Available Sensors
 
 **Temperature Sensors:**
@@ -123,3 +130,23 @@ The integration includes a comprehensive test suite using pytest with Home Assis
 - Create realistic mock data that matches expected API responses
 - Test both happy path and error conditions
 - Use pytest fixtures for consistent test data
+
+## Debugging Sensor Issues
+
+### Common Sensor Problems
+- **"Unknown" Values**: Usually indicates incorrect data key mapping between pycompool API and const.py
+- **Missing Fields**: Some sensor values need to be computed from other status fields (e.g., active_heat_source)
+- **Temperature Mapping**: Ensure temperature sensor keys match pycompool's exact field names
+
+### Debugging Steps
+1. **Check pycompool API docs** for actual field names and data structure
+2. **Verify const.py mappings** - ensure KEY_* constants match pycompool field names exactly
+3. **Add computed fields** in coordinator's `_enhance_status_data()` method for derived values
+4. **Update test mock data** to match real pycompool response format
+5. **Use `uv run python -c "..."` for testing** - never use `python3` directly
+
+### Key API Differences to Watch For
+- pycompool uses `"version"` not `"firmware"` for firmware version
+- Active heat source must be computed from `heater_on`/`solar_on` booleans
+- Temperature field naming is inconsistent (some have _f suffix, some don't)
+- Time is "HH:MM" format, not ISO timestamps

--- a/custom_components/compool/const.py
+++ b/custom_components/compool/const.py
@@ -27,14 +27,14 @@ CONF_PORT = "port"
 DEFAULT_PORT = 8899
 
 # Pool controller status data keys
-KEY_FIRMWARE = "firmware"
+KEY_FIRMWARE = "version"
 KEY_TIME = "time"
 KEY_POOL_WATER_TEMP = "pool_water_temp_f"
 KEY_SPA_WATER_TEMP = "spa_water_temp_f"
-KEY_SPA_SOLAR_TEMP = "spa_solar_temp_f"
-KEY_POOL_AIR_TEMP = "pool_air_temp_f"
-KEY_SOLAR_COLLECTOR_TEMP = "solar_collector_temp_f"
-KEY_ACTIVE_HEAT_SOURCE = "active_heat_source"
+KEY_SPA_SOLAR_TEMP = "spa_solar_temp"  # Note: no _f suffix in pycompool
+KEY_POOL_AIR_TEMP = "air_temp_f"
+KEY_SOLAR_COLLECTOR_TEMP = "pool_solar_temp_f"  # This is the solar collector temp
+KEY_ACTIVE_HEAT_SOURCE = "active_heat_source"  # Will be computed from heat source bits
 KEY_HEAT_DELAY_ACTIVE = "heat_delay_active"
 KEY_FREEZE_PROTECTION_ACTIVE = "freeze_protection_active"
 KEY_AIR_SENSOR_FAULT = "air_sensor_fault"

--- a/custom_components/compool/coordinator.py
+++ b/custom_components/compool/coordinator.py
@@ -69,6 +69,21 @@ class CompoolStatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Raise UpdateFailed for no status data."""
         raise UpdateFailed("No status data received from pool controller")
 
+    def _enhance_status_data(self, status: dict[str, Any]) -> None:
+        """Add computed fields to status data."""
+        # Compute active heat source based on current heating activity
+        # According to pycompool docs, we can determine active heat source from heater_on and solar_on
+        if status.get("heater_on") and status.get("solar_on"):
+            active_heat_source = "heater+solar"
+        elif status.get("heater_on"):
+            active_heat_source = "heater"
+        elif status.get("solar_on"):
+            active_heat_source = "solar"
+        else:
+            active_heat_source = "off"
+
+        status["active_heat_source"] = active_heat_source
+
     def _get_pool_status_with_retry(self) -> dict[str, Any]:
         """Get pool controller status with retry logic for connection failures."""
         max_retries = 3
@@ -87,6 +102,8 @@ class CompoolStatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if not status:
                     self._raise_no_status_error()
                 else:
+                    # Enhance status with computed fields
+                    self._enhance_status_data(status)
                     return status
 
             except Exception as ex:

--- a/tests/const.py
+++ b/tests/const.py
@@ -3,14 +3,16 @@
 MOCK_CONFIG = {"host": "192.168.1.100", "port": 8899}
 
 MOCK_POOL_STATUS = {
-    "firmware": "v2.1.3",
-    "time": "2025-06-18T15:30:00Z",
+    "version": 23,  # Firmware version as integer
+    "time": "15:30",  # Time as HH:MM string
     "pool_water_temp_f": 82.5,
     "spa_water_temp_f": 104.2,
-    "spa_solar_temp_f": 78.1,
-    "pool_air_temp_f": 75.8,
-    "solar_collector_temp_f": 95.3,
-    "active_heat_source": "solar",
+    "spa_solar_temp": 78.1,  # No _f suffix for spa solar
+    "air_temp_f": 75.8,
+    "pool_solar_temp_f": 95.3,  # This is the solar collector temp
+    "heater_on": False,
+    "solar_on": True,
+    "active_heat_source": "solar",  # Will be computed by coordinator
     "heat_delay_active": False,
     "freeze_protection_active": False,
     "air_sensor_fault": False,


### PR DESCRIPTION
## Summary
  - Fix Pool Controller Firmware sensor showing "Unknown" by using correct 'version' key from pycompool API
  - Fix Pool Controller Active Heat Source sensor by computing value from heater_on/solar_on status
  - Update temperature sensor key mappings to match pycompool library format

  ## Changes Made
  - **Firmware Sensor**: Changed key from `"firmware"` to `"version"` to match pycompool API
  - **Active Heat Source**: Added computed field logic that determines active heat source from `heater_on` and `solar_on` status
  - **Temperature Key Corrections**: Updated various temperature sensor keys to match pycompool format (e.g., `air_temp_f`, `pool_solar_temp_f`)
  - **Test Data Updates**: Updated mock test data to reflect actual pycompool response structure

  ## Files Changed
  - `custom_components/compool/const.py` - Updated sensor key constants
  - `custom_components/compool/coordinator.py` - Added `_enhance_status_data()` method
  - `tests/const.py` - Updated mock data to match pycompool API format

  ## Test plan
  - [x] All existing tests pass
  - [x] Sensor key mappings verified against pycompool documentation
  - [x] Mock test data updated to match actual API response format
  - [x] Code passes linting checks

  This resolves sensors showing "Unknown" values by ensuring proper data key mapping between the pycompool library and Home Assistant sensor entities.

  🤖 Generated with [Claude Code](https://claude.ai/code)