### PR TITLE
Make timeout/retry more lenient for pool controller connections

### DIFF
--- a/custom_components/compool/coordinator.py
+++ b/custom_components/compool/coordinator.py
@@ -86,8 +86,8 @@ class CompoolStatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _get_pool_status_with_retry(self) -> dict[str, Any]:
         """Get pool controller status with retry logic for connection failures."""
-        max_retries = 3
-        base_delay = 2  # seconds
+        max_retries = 5
+        base_delay = 3  # seconds
 
         for attempt in range(max_retries + 1):
             try:


### PR DESCRIPTION
## Summary
- Increase max retries from 3 to 5 attempts for better resilience
- Extend base delay from 2 to 3 seconds to handle slower connections
- Improves tolerance for temporary network issues and slow controller responses

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] Retry sequence now: 3, 6, 12, 24, 48 seconds between attempts
- [x] Maintains 30-second polling frequency as requested

🤖 Generated with [Claude Code](https://claude.ai/code)