### PR TITLE
Add flox environment configuration

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -1,0 +1,36 @@
+version = 1
+
+[install]
+python313.pkg-path = "python313"
+git.pkg-path = "git"
+bash.pkg-path = "bash"
+uv.pkg-path = "uv"
+ruff.pkg-path = "ruff"
+pkg-config.pkg-path = "pkg-config"
+gcc.pkg-path = "gcc"
+rustc.pkg-path = "rustc"
+
+[vars]
+PYTHONPATH = "./custom_components"
+UV_PYTHON = "3.13.3"
+
+[hook]
+on-activate = '''
+echo "🏊 Home Assistant Compool Integration Environment"
+echo "Python: $(python --version)"
+echo "uv: $(uv --version)"
+
+if [ ! -d ".venv" ]; then
+  echo "Setting up Python environment..."
+  uv venv --python 3.13.3
+  uv pip install -e ".[dev]"
+fi
+
+source .venv/bin/activate
+
+echo "Available commands:"
+echo "  scripts/setup   - Set up development environment"
+echo "  scripts/develop - Start Home Assistant in debug mode"
+echo "  scripts/lint    - Format and lint code"
+echo "  scripts/test    - Run test suite"
+'''


### PR DESCRIPTION
## Summary
- Add flox environment manifest for consistent cross-platform development setup
- Includes Python 3.13.3, development tools (uv, ruff), and build dependencies
- On-activate hook automatically sets up Python venv and displays helpful commands
- Supports Linux and macOS (Intel/ARM architectures)

## Benefits
- Reproducible development environment across different machines
- Automatic dependency management through flox
- Simplified onboarding for new contributors
- Consistent tooling versions (ruff, Python, etc.)

## Test plan
- [ ] Verify `flox activate` works and shows welcome message
- [ ] Confirm Python venv is created automatically on first activation  
- [ ] Test that development scripts work within flox environment
- [ ] Validate cross-platform compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)