### PR TITLE
Fix heat source and heater_on implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,14 @@ The integration utilizes pycompool APIs:
 - ✅ Connection management - Automatic connect/disconnect for each status query
 
 ### Important API Data Structure Notes
-- **Firmware Version**: pycompool returns `"version"` key (integer), not `"firmware"` 
-- **Active Heat Source**: No direct field - must be computed from `heater_on` and `solar_on` boolean status
+- **Firmware Version**: pycompool returns `"version"` key (integer), not `"firmware"`
+- **Heat Source Configuration**:
+  - `heat_source`: Pool heat mode configuration (`'heater'`, `'solar-priority'`, `'solar-only'`, or `'off'`)
+  - `spa_heat_source`: Spa heat mode configuration (`'heater'`, `'solar-priority'`, `'solar-only'`, or `'off'`)
+  - These fields indicate the *configured* heating mode, not the current active state
+- **Heater Active Status**:
+  - `heater_on`: Boolean indicating whether the heater is *actively running* right now
+  - This is separate from the configured heat mode
 - **Temperature Keys**: Follow specific naming conventions (e.g., `air_temp_f`, `pool_solar_temp_f`, `spa_solar_temp` without _f suffix)
 - **Time Format**: Returns as "HH:MM" string format, not ISO timestamp
 - **Status Fields**: Include `heater_on`, `solar_on`, `freeze_protection_active`, sensor fault flags
@@ -63,9 +69,11 @@ The integration utilizes pycompool APIs:
 **Status Sensors:**
 - `sensor.pool_controller_firmware` - Controller firmware version
 - `sensor.pool_controller_time` - Controller timestamp
-- `sensor.pool_active_heat_source` - Currently active heating source
+- `sensor.pool_heat_source` - Pool heating mode configuration (heater/solar-priority/solar-only/off)
+- `sensor.spa_heat_source` - Spa heating mode configuration (heater/solar-priority/solar-only/off)
 
 **Binary Sensors:**
+- `binary_sensor.heater_on` - Whether heater is actively running (separate from configured mode)
 - `binary_sensor.heat_delay_active` - Heat delay status
 - `binary_sensor.freeze_protection_active` - Freeze protection status
 - `binary_sensor.air_sensor_fault` - Air sensor fault indicator
@@ -159,19 +167,19 @@ The integration includes a comprehensive test suite using pytest with Home Assis
 
 ### Common Sensor Problems
 - **"Unknown" Values**: Usually indicates incorrect data key mapping between pycompool API and const.py
-- **Missing Fields**: Some sensor values need to be computed from other status fields (e.g., active_heat_source)
+- **Missing Fields**: Verify that pycompool status includes the expected field
 - **Temperature Mapping**: Ensure temperature sensor keys match pycompool's exact field names
 
 ### Debugging Steps
 1. **Check pycompool API docs** for actual field names and data structure
 2. **Verify const.py mappings** - ensure KEY_* constants match pycompool field names exactly
-3. **Add computed fields** in coordinator's `_enhance_status_data()` method for derived values
-4. **Update test mock data** to match real pycompool response format
-5. **Use `uv run python -c "..."` for testing** - never use `python3` directly
+3. **Update test mock data** to match real pycompool response format
+4. **Use `uv run python -c "..."` for testing** - never use `python3` directly
 
 ### Key API Differences to Watch For
 - pycompool uses `"version"` not `"firmware"` for firmware version
-- Active heat source must be computed from `heater_on`/`solar_on` booleans
+- `heat_source` and `spa_heat_source` are configured modes, not active status
+- `heater_on` is a boolean showing active heater status, separate from configured mode
 - Temperature field naming is inconsistent (some have _f suffix, some don't)
 - Time is "HH:MM" format, not ISO timestamps
 

--- a/custom_components/compool/binary_sensor.py
+++ b/custom_components/compool/binary_sensor.py
@@ -15,6 +15,7 @@ from .const import (
     KEY_AIR_SENSOR_FAULT,
     KEY_FREEZE_PROTECTION_ACTIVE,
     KEY_HEAT_DELAY_ACTIVE,
+    KEY_HEATER_ON,
     KEY_SOLAR_PRESENT,
     KEY_SOLAR_SENSOR_FAULT,
     KEY_WATER_SENSOR_FAULT,
@@ -23,6 +24,12 @@ from .coordinator import CompoolConfigEntry
 from .entity import CompoolEntity
 
 COMPOOL_BINARY_SENSORS: tuple[BinarySensorEntityDescription, ...] = (
+    BinarySensorEntityDescription(
+        key="heater_on",
+        translation_key="heater_on",
+        icon="mdi:radiator",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     BinarySensorEntityDescription(
         key="heat_delay_active",
         translation_key="heat_delay_active",
@@ -102,7 +109,9 @@ class CompoolBinarySensor(CompoolEntity, BinarySensorEntity):
         sensor_key = self.entity_description.key
         status = self.coordinator.data
 
-        if sensor_key == "heat_delay_active":
+        if sensor_key == "heater_on":
+            return status.get(KEY_HEATER_ON, False)
+        elif sensor_key == "heat_delay_active":
             return status.get(KEY_HEAT_DELAY_ACTIVE, False)
         elif sensor_key == "freeze_protection_active":
             return status.get(KEY_FREEZE_PROTECTION_ACTIVE, False)

--- a/custom_components/compool/const.py
+++ b/custom_components/compool/const.py
@@ -37,7 +37,13 @@ KEY_SPA_WATER_TEMP = "spa_water_temp_f"
 KEY_SPA_SOLAR_TEMP = "spa_solar_temp"  # Note: no _f suffix in pycompool
 KEY_POOL_AIR_TEMP = "air_temp_f"
 KEY_SOLAR_COLLECTOR_TEMP = "pool_solar_temp_f"  # This is the solar collector temp
-KEY_ACTIVE_HEAT_SOURCE = "active_heat_source"  # Will be computed from heat source bits
+KEY_HEAT_SOURCE = (
+    "heat_source"  # Pool heat mode: 'heater', 'solar-priority', 'solar-only', 'off'
+)
+KEY_SPA_HEAT_SOURCE = (
+    "spa_heat_source"  # Spa heat mode: 'heater', 'solar-priority', 'solar-only', 'off'
+)
+KEY_HEATER_ON = "heater_on"  # Boolean: whether heater is actively running
 KEY_HEAT_DELAY_ACTIVE = "heat_delay_active"
 KEY_FREEZE_PROTECTION_ACTIVE = "freeze_protection_active"
 KEY_AIR_SENSOR_FAULT = "air_sensor_fault"

--- a/custom_components/compool/coordinator.py
+++ b/custom_components/compool/coordinator.py
@@ -69,21 +69,6 @@ class CompoolStatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Raise UpdateFailed for no status data."""
         raise UpdateFailed("No status data received from pool controller")
 
-    def _enhance_status_data(self, status: dict[str, Any]) -> None:
-        """Add computed fields to status data."""
-        # Compute active heat source based on current heating activity
-        # According to pycompool docs, we can determine active heat source from heater_on and solar_on
-        if status.get("heater_on") and status.get("solar_on"):
-            active_heat_source = "heater+solar"
-        elif status.get("heater_on"):
-            active_heat_source = "heater"
-        elif status.get("solar_on"):
-            active_heat_source = "solar"
-        else:
-            active_heat_source = "off"
-
-        status["active_heat_source"] = active_heat_source
-
     def _get_pool_status_with_retry(self) -> dict[str, Any]:
         """Get pool controller status with retry logic for connection failures."""
         max_retries = 5
@@ -102,8 +87,6 @@ class CompoolStatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if not status:
                     self._raise_no_status_error()
                 else:
-                    # Enhance status with computed fields
-                    self._enhance_status_data(status)
                     return status
 
             except Exception as ex:

--- a/custom_components/compool/select.py
+++ b/custom_components/compool/select.py
@@ -73,25 +73,8 @@ class CompoolPoolHeaterModeSelect(CompoolEntity, SelectEntity):
         if self.coordinator.data is None:
             return None
 
-        # Extract heat source configuration from status data
-        # This would need to be added to the coordinator's _enhance_status_data method
-        # For now, we'll determine from the boolean flags
-        status = self.coordinator.data
-
-        # Check if pool heater/solar are on to determine current mode
-        heater_on = status.get("heater_on", False)
-        solar_on = status.get("solar_on", False)
-
-        if not heater_on and not solar_on:
-            return "off"
-        elif heater_on and solar_on:
-            return "solar-priority"  # Both are active
-        elif heater_on:
-            return "heater"
-        elif solar_on:
-            return "solar-only"
-        else:
-            return "off"
+        # Read heat source configuration directly from status data
+        return self.coordinator.data.get("heat_source")
 
     async def async_select_option(self, option: str) -> None:
         """Set pool heater mode."""
@@ -121,26 +104,8 @@ class CompoolSpaHeaterModeSelect(CompoolEntity, SelectEntity):
         if self.coordinator.data is None:
             return None
 
-        # Extract spa heat source configuration from status data
-        # This would need to be enhanced based on the actual pycompool data structure
-        # For 3830 systems, spa heater and solar status are in separate bits
-        status = self.coordinator.data
-
-        # Check spa-specific heater/solar status (for 3830 systems)
-        # These fields may need to be added to the coordinator's data parsing
-        spa_heater_on = status.get("spa_heater_on", False)
-        spa_solar_on = status.get("spa_solar_on", False)
-
-        if not spa_heater_on and not spa_solar_on:
-            return "off"
-        elif spa_heater_on and spa_solar_on:
-            return "solar-priority"  # Both are active
-        elif spa_heater_on:
-            return "heater"
-        elif spa_solar_on:
-            return "solar-only"
-        else:
-            return "off"
+        # Read spa heat source configuration directly from status data
+        return self.coordinator.data.get("spa_heat_source")
 
     async def async_select_option(self, option: str) -> None:
         """Set spa heater mode."""

--- a/custom_components/compool/sensor.py
+++ b/custom_components/compool/sensor.py
@@ -13,11 +13,12 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .const import (
-    KEY_ACTIVE_HEAT_SOURCE,
     KEY_FIRMWARE,
+    KEY_HEAT_SOURCE,
     KEY_POOL_AIR_TEMP,
     KEY_POOL_WATER_TEMP,
     KEY_SOLAR_COLLECTOR_TEMP,
+    KEY_SPA_HEAT_SOURCE,
     KEY_SPA_SOLAR_TEMP,
     KEY_SPA_WATER_TEMP,
     KEY_TIME,
@@ -37,8 +38,13 @@ COMPOOL_SENSORS: tuple[SensorEntityDescription, ...] = (
         icon="mdi:clock",
     ),
     SensorEntityDescription(
-        key="pool_active_heat_source",
-        translation_key="pool_active_heat_source",
+        key="pool_heat_source",
+        translation_key="pool_heat_source",
+        icon="mdi:fire",
+    ),
+    SensorEntityDescription(
+        key="spa_heat_source",
+        translation_key="spa_heat_source",
         icon="mdi:fire",
     ),
     SensorEntityDescription(
@@ -126,8 +132,10 @@ class CompoolSensor(CompoolEntity, SensorEntity):
             return status.get(KEY_FIRMWARE)
         elif sensor_key == "pool_controller_time":
             return status.get(KEY_TIME)
-        elif sensor_key == "pool_active_heat_source":
-            return status.get(KEY_ACTIVE_HEAT_SOURCE)
+        elif sensor_key == "pool_heat_source":
+            return status.get(KEY_HEAT_SOURCE)
+        elif sensor_key == "spa_heat_source":
+            return status.get(KEY_SPA_HEAT_SOURCE)
         elif sensor_key == "pool_water_temperature":
             return status.get(KEY_POOL_WATER_TEMP)
         elif sensor_key == "spa_water_temperature":

--- a/tests/const.py
+++ b/tests/const.py
@@ -18,11 +18,10 @@ MOCK_POOL_STATUS = {
     "pool_solar_temp_f": 95.3,  # This is the solar collector temp
     "desired_pool_temp_f": 80.0,  # Target pool temperature
     "desired_spa_temp_f": 104.0,  # Target spa temperature
-    "heater_on": True,
+    "heat_source": "heater",  # Pool heat mode configuration
+    "spa_heat_source": "solar-priority",  # Spa heat mode configuration
+    "heater_on": True,  # Boolean: heater actively running
     "solar_on": False,
-    "spa_heater_on": False,  # For spa heater mode select
-    "spa_solar_on": False,  # For spa heater mode select
-    "active_heat_source": "heater",  # Will be computed by coordinator
     "heat_delay_active": False,
     "freeze_protection_active": False,
     "air_sensor_fault": False,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -24,8 +24,8 @@ async def test_binary_sensors(hass: HomeAssistant) -> None:
         if state.entity_id.startswith("binary_sensor.")
     ]
 
-    # We should have 6 binary sensors
-    assert len(binary_sensors) == 6
+    # We should have 7 binary sensors (added heater_on)
+    assert len(binary_sensors) == 7
 
     # All binary sensors should be from this integration - entity IDs now use device name + translation key
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -65,7 +65,7 @@ async def test_pool_heater_mode_value(hass: HomeAssistant, bypass_get_data) -> N
     if state is None:
         # Skip test if entity not created (platform loading issue)
         return
-    # Based on MOCK_POOL_STATUS heater_on=True, solar_on=False
+    # Based on MOCK_POOL_STATUS heat_source="heater"
     assert state.state == "heater"
     assert "off" in state.attributes["options"]
     assert "heater" in state.attributes["options"]
@@ -91,8 +91,8 @@ async def test_spa_heater_mode_value(hass: HomeAssistant, bypass_get_data) -> No
     if state is None:
         # Skip test if entity not created (platform loading issue)
         return
-    # Based on MOCK_POOL_STATUS spa_heater_on=False, spa_solar_on=False
-    assert state.state == "off"
+    # Based on MOCK_POOL_STATUS spa_heat_source="solar-priority"
+    assert state.state == "solar-priority"
 
 
 async def test_set_pool_heater_mode(hass: HomeAssistant, bypass_get_data) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -24,8 +24,8 @@ async def test_sensors(hass: HomeAssistant) -> None:
         if state.entity_id.startswith("sensor.")
     ]
 
-    # We should have 8 sensors
-    assert len(sensors) == 8
+    # We should have 9 sensors (added spa_heat_source)
+    assert len(sensors) == 9
 
     # All sensors should be from this integration - entity IDs now use device name + translation key
     for sensor in sensors:


### PR DESCRIPTION
## Summary

Fixes incorrect implementation of heat source sensors and adds missing heater status monitoring.

Previously, the integration incorrectly computed heat source status from `heater_on`/`solar_on` boolean flags. The pycompool library actually provides separate fields for:
- **Configured heat mode** (`heat_source`, `spa_heat_source`)
- **Active heater status** (`heater_on`)

## Changes

### Sensors
- ✅ Replaced `sensor.pool_active_heat_source` with `sensor.pool_heat_source` (reads configured mode)
- ✅ Added `sensor.spa_heat_source` (reads configured spa heat mode)
- ✅ Added `binary_sensor.heater_on` (shows when heater is actively running)

### Select Entities
- ✅ Fixed pool/spa heater mode selects to read `heat_source`/`spa_heat_source` directly from status
- ✅ Removed incorrect boolean computation logic

### Code Quality
- ✅ Removed `_enhance_status_data()` method that was computing non-existent fields
- ✅ Updated const.py with correct key constants
- ✅ Updated CLAUDE.md documentation
- ✅ All tests passing (28/28)
- ✅ Linting passed

## Testing

```bash
$ scripts/test
============================== 28 passed in 0.87s ==============================

$ scripts/lint
All checks passed!
```

## API Clarification

**pycompool provides:**
- `heat_source`: Pool heat mode configuration (`'heater'`, `'solar-priority'`, `'solar-only'`, `'off'`)
- `spa_heat_source`: Spa heat mode configuration (`'heater'`, `'solar-priority'`, `'solar-only'`, `'off'`)
- `heater_on`: Boolean indicating whether the heater is actively running

The configured mode (heat_source) is separate from whether the heater is currently active (heater_on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)